### PR TITLE
Adapt plugin to GitBook 3

### DIFF
--- a/book/script.js
+++ b/book/script.js
@@ -1,4 +1,4 @@
-require(["jquery", "lodash", "gitbook"], function($, _, gitbook) {
+require(["jquery", "gitbook"], function($, gitbook) {
   var configuration = {"labels": {}, text: {}, "buttons": {"showCorrect": true, "showExplanation": true}};
   var isStarted = false;
   /**
@@ -48,6 +48,16 @@ require(["jquery", "lodash", "gitbook"], function($, _, gitbook) {
     }
     return result;
   }
+  /**
+   * Asserts value is a String object
+   *
+   * @param {String} [value]
+   * @returns {Bool}
+   */
+   function isString(value) {
+    return typeof value == 'string' ||
+        (!$.isArray(value) && (!!value && typeof value == 'object') && Object.prototype.toString.call(value) == '[object String]');
+   }
 
   /**
    * Template for the whole question
@@ -61,7 +71,7 @@ require(["jquery", "lodash", "gitbook"], function($, _, gitbook) {
     html = "";
 
     question = $el.find("p").first().html();
-    multiple = _.isString($el.attr("multiple"));
+    multiple = isString($el.attr("multiple"));
     $answers = $el.find("answer");
     $explanation = $el.find("explanation");
 
@@ -122,7 +132,7 @@ require(["jquery", "lodash", "gitbook"], function($, _, gitbook) {
   var answerTemplate = function ($el, multiple, name) {
     var correct, text, html, $options;
 
-    correct = _.isString($el.attr("correct"));
+    correct = isString($el.attr("correct"));
     text = $el.text();
     html = $el.html();
     $options = $el.find("option");
@@ -130,9 +140,9 @@ require(["jquery", "lodash", "gitbook"], function($, _, gitbook) {
       var result;
 
       result = "<div class=\"quiz-answer\"><select>";
-      _.each($options, function (option) {
+      $.each($options, function (i, option) {
         var $option = $(option);
-        result += "<option data-correct=" + _.isString($option.attr("correct")) + ">" + $option.text() + "</option>";
+        result += "<option data-correct=" + isString($option.attr("correct")) + ">" + $option.text() + "</option>";
       });
       result += "</select>" + "<span class=\"quiz-answer-check\"></span></div>";
       return result;


### PR DESCRIPTION
Hello,

We will soon release [GitBook v3](https://github.com/GitbookIO/gitbook).
The plugins API has been updated, as you will see [in the GitBook 3 documentation](http://toolchain.gitbook.com/).

I'm in charge of reviewing the existing plugins for maintaining the compatibility with this new version.
In this version, GitBook will not provide `lodash` to front-end anymore, hence your plugin will not work correctly.

The proposed PR has been tested with the new version. It simply implements directly `_.isString()` and replaces `_.each()` by jQuery's `$.each()`.
Let me know if you have any remarks regarding what have been done, and don't forget to publish a new version if you merge it :)

Kind regards,
Johan
